### PR TITLE
Add "Hide completed" checkbox to Tracks layer for improved visualization

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -661,6 +661,7 @@ module = [
     'napari._qt.layer_controls.widgets._tracks.qt_id_checkbox',
     'napari._qt.layer_controls.widgets._tracks.qt_graph_checkbox',
     'napari._qt.layer_controls.widgets._tracks.qt_colormap_control',
+    'napari._qt.layer_controls.widgets._tracks.qt_hide_completed_tracks_checkbox',
     'napari._qt.menus._util',
     'napari._qt.menus.file_menu',
     'napari._qt.perf.qt_event_tracing',

--- a/src/napari/_qt/layer_controls/qt_tracks_controls.py
+++ b/src/napari/_qt/layer_controls/qt_tracks_controls.py
@@ -6,6 +6,7 @@ from napari._qt.layer_controls.widgets._tracks import (
     QtColorPropertiesComboBoxControl,
     QtGraphCheckBoxControl,
     QtHeadLengthSliderControl,
+    QtHideCompletedTracksCheckBoxControl,
     QtIdCheckBoxControl,
     QtTailDisplayCheckBoxControl,
     QtTailLengthSliderControl,
@@ -43,6 +44,8 @@ class QtTracksControls(QtLayerControls):
         Widget that wraps a slider controlling tail length of the layer.
     _tail_width_slider_control : napari._qt.layer_controls.widgets._tracks.QtTailWidthSliderControl
         Widget that wraps a slider controlling tail width of the layer.
+    _hide_completed_tracks_checkbox_control : napari._qt.layer_controls.widgets._tracks.QtHideCompletedTracksCheckBoxControl
+        Widget that wraps a checkbox controlling if completed tracks of the layer should be hidden.
     """
 
     layer: 'napari.layers.Tracks'
@@ -79,3 +82,7 @@ class QtTracksControls(QtLayerControls):
         self._add_widget_controls(self._id_checkbox_control)
         self._graph_checkbox_control = QtGraphCheckBoxControl(self, layer)
         self._add_widget_controls(self._graph_checkbox_control)
+        self._hide_completed_tracks_checkbox_control = (
+            QtHideCompletedTracksCheckBoxControl(self, layer)
+        )
+        self._add_widget_controls(self._hide_completed_tracks_checkbox_control)

--- a/src/napari/_qt/layer_controls/widgets/_tracks/__init__.py
+++ b/src/napari/_qt/layer_controls/widgets/_tracks/__init__.py
@@ -10,6 +10,9 @@ from napari._qt.layer_controls.widgets._tracks.qt_graph_checkbox import (
 from napari._qt.layer_controls.widgets._tracks.qt_head_slider import (
     QtHeadLengthSliderControl,
 )
+from napari._qt.layer_controls.widgets._tracks.qt_hide_completed_tracks_checkbox import (
+    QtHideCompletedTracksCheckBoxControl,
+)
 from napari._qt.layer_controls.widgets._tracks.qt_id_checkbox import (
     QtIdCheckBoxControl,
 )
@@ -24,6 +27,7 @@ __all__ = [
     'QtColormapComboBoxControl',
     'QtGraphCheckBoxControl',
     'QtHeadLengthSliderControl',
+    'QtHideCompletedTracksCheckBoxControl',
     'QtIdCheckBoxControl',
     'QtTailDisplayCheckBoxControl',
     'QtTailLengthSliderControl',

--- a/src/napari/_qt/layer_controls/widgets/_tracks/qt_hide_completed_tracks_checkbox.py
+++ b/src/napari/_qt/layer_controls/widgets/_tracks/qt_hide_completed_tracks_checkbox.py
@@ -1,0 +1,66 @@
+from qtpy.QtWidgets import (
+    QCheckBox,
+    QWidget,
+)
+
+from napari._qt.layer_controls.widgets.qt_widget_controls_base import (
+    QtWidgetControlsBase,
+    QtWrappedLabel,
+)
+from napari._qt.utils import checked_to_bool, qt_signals_blocked
+from napari.layers import Tracks
+from napari.utils.events.event_utils import connect_setattr
+from napari.utils.translations import trans
+
+
+class QtHideCompletedTracksCheckBoxControl(QtWidgetControlsBase):
+    """
+    Class that wraps the connection of events/signals between the hide completed
+    tracks attribute and Qt widgets.
+
+    Parameters
+    ----------
+    parent: qtpy.QtWidgets.QWidget
+        An instance of QWidget that will be used as widgets parent
+    layer : napari.layers.Tracks
+        An instance of a napari Tracks layer.
+
+    Attributes
+    ----------
+    hide_completed_tracks_checkbox : qtpy.QtWidgets.QCheckBox
+        Checkbox controlling if completed tracks should be hidden.
+    hide_completed_tracks_checkbox_label : napari._qt.layer_controls.widgets.qt_widget_controls_base.QtWrappedLabel
+        Label for showing the option checkbox.
+    """
+
+    def __init__(self, parent: QWidget, layer: Tracks) -> None:
+        super().__init__(parent, layer)
+        # Setup layer
+
+        # Setup widgets
+        self.hide_completed_tracks_checkbox = QCheckBox()
+        connect_setattr(
+            self.hide_completed_tracks_checkbox.stateChanged,
+            layer,
+            'hide_completed_tracks',
+            convert_fun=checked_to_bool,
+        )
+
+        self.hide_completed_tracks_checkbox_label = QtWrappedLabel(
+            trans._('hide completed:')
+        )
+
+    def _on_hide_completed_tracks_change(self) -> None:
+        """Receive layer model hide_completed_tracks event and update the checkbox."""
+        with qt_signals_blocked(self.hide_completed_tracks_checkbox):
+            self.hide_completed_tracks_checkbox.setChecked(
+                self._layer.hide_completed_tracks
+            )
+
+    def get_widget_controls(self) -> list[tuple[QtWrappedLabel, QWidget]]:
+        return [
+            (
+                self.hide_completed_tracks_checkbox_label,
+                self.hide_completed_tracks_checkbox,
+            )
+        ]

--- a/src/napari/_vispy/filters/tracks.py
+++ b/src/napari/_vispy/filters/tracks.py
@@ -29,13 +29,6 @@ class TracksFilter(Filter):
         this will enable/disable tail fading with time
     vertex_time : 1D array, list
         a vector describing the time associated with each vertex
-
-    TODO
-    ----
-    - the track is still displayed, albeit with fading, once the track has
-     finished but is still within the 'tail_length' window. Should it
-     disappear?
-
     """
 
     VERT_SHADER = """

--- a/src/napari/_vispy/layers/tracks.py
+++ b/src/napari/_vispy/layers/tracks.py
@@ -19,6 +19,7 @@ class VispyTracksLayer(VispyBaseLayer):
         self.layer.events.display_id.connect(self._on_appearance_change)
         self.layer.events.display_tail.connect(self._on_appearance_change)
         self.layer.events.display_graph.connect(self._on_appearance_change)
+        self.layer.events.hide_completed_tracks.connect(self._on_tracks_change)
 
         self.layer.events.color_by.connect(self._on_appearance_change)
         self.layer.events.colormap.connect(self._on_appearance_change)
@@ -45,6 +46,11 @@ class VispyTracksLayer(VispyBaseLayer):
             self.node._subvisuals[1].text = labels_text
             self.node._subvisuals[1].pos = labels_pos
 
+        # If hide_completed_tracks is enabled, update track connections
+        # when the current time changes
+        if self.layer.hide_completed_tracks:
+            self._on_tracks_change()
+
         self.node.update()
         # Call to update order of translation values with new dims:
         self._on_matrix_change()
@@ -56,9 +62,15 @@ class VispyTracksLayer(VispyBaseLayer):
         self.node.tracks_filter.use_fade = self.layer.use_fade
         self.node.tracks_filter.tail_length = self.layer.tail_length
         self.node.tracks_filter.head_length = self.layer.head_length
+        self.node.tracks_filter.hide_completed_tracks = (
+            self.layer.hide_completed_tracks
+        )
         self.node.graph_filter.use_fade = self.layer.use_fade
         self.node.graph_filter.tail_length = self.layer.tail_length
         self.node.graph_filter.head_length = self.layer.head_length
+        self.node.graph_filter.hide_completed_tracks = (
+            self.layer.hide_completed_tracks
+        )
 
         # set visibility of subvisuals
         self.node._subvisuals[0].visible = self.layer.display_tail
@@ -80,6 +92,9 @@ class VispyTracksLayer(VispyBaseLayer):
         self.node.tracks_filter.use_fade = self.layer.use_fade
         self.node.tracks_filter.tail_length = self.layer.tail_length
         self.node.tracks_filter.vertex_time = self.layer.track_times
+        self.node.tracks_filter.hide_completed_tracks = (
+            self.layer.hide_completed_tracks
+        )
 
         # change the data to the vispy line visual
         self.node._subvisuals[0].set_data(

--- a/src/napari/layers/tracks/_tests/test_tracks.py
+++ b/src/napari/layers/tracks/_tests/test_tracks.py
@@ -2,6 +2,7 @@ import numpy as np
 import pandas as pd
 import pytest
 
+from napari.components.dims import Dims
 from napari.layers import Tracks
 from napari.layers.tracks._track_utils import TrackManager
 from napari.utils._test_utils import (
@@ -306,6 +307,110 @@ def test_track_coloring() -> None:
     layer.track_colors = colors
 
     assert np.array_equal(layer._track_colors, colors)
+
+
+def test_hide_completed_tracks() -> None:
+    """Test that hide_completed_tracks correctly masks track_connex for completed tracks."""
+
+    # Create test data with multiple tracks that finish at different times
+    # Track 0: time 0-2 (finishes at t=2)
+    # Track 1: time 3-5 (finishes at t=5)
+    # Track 2: time 0-7 (finishes at t=7)
+    data = np.array(
+        [
+            [0, 0, 10, 10],  # Track 0
+            [0, 1, 11, 11],
+            [0, 2, 12, 12],
+            [1, 3, 20, 20],  # Track 1
+            [1, 4, 21, 21],
+            [1, 5, 22, 22],
+            [2, 0, 30, 30],  # Track 2
+            [2, 1, 31, 31],
+            [2, 2, 32, 32],
+            [2, 3, 33, 33],
+            [2, 4, 34, 34],
+            [2, 5, 35, 35],
+            [2, 6, 36, 36],
+            [2, 7, 37, 37],
+        ]
+    )
+
+    layer = Tracks(data)
+
+    # Test initial state - hide_completed_tracks should be False by default
+    assert layer.hide_completed_tracks is False
+
+    # Get original track_connex (should not be masked)
+    original_connex = layer.track_connex.copy()
+
+    # Enable hide_completed_tracks
+    layer.hide_completed_tracks = True
+
+    # Test at time point 4 (Track 0 completed at t=2, Track 1 and 2 still active)
+    # Need to explicitly set range to include time 4
+    dims = Dims(
+        ndim=layer.ndim,
+        point=(4, 0, 0),
+        range=((0, 8, 1), (0, 50, 1), (0, 50, 1)),
+    )  # Extended range for time
+    layer._slice_dims(dims)
+
+    masked_connex = layer.track_connex
+
+    # Track 0 should be completely masked (completed before t=4)
+    track_0_indices = np.where(layer.data[:, 0] == 0)[0]
+
+    # All connections for track 0 should be False when hide_completed_tracks is enabled
+    assert np.all(~masked_connex[track_0_indices])  # all False
+
+    # Track 1 and 2 should still have their original connections (not completed)
+    track_1_indices = np.where(layer.data[:, 0] == 1)[0]
+    track_2_indices = np.where(layer.data[:, 0] == 2)[0]
+
+    # For tracks 1 and 2, connections should match original (except last vertex of each track)
+    np.testing.assert_array_equal(
+        masked_connex[track_1_indices], original_connex[track_1_indices]
+    )
+    np.testing.assert_array_equal(
+        masked_connex[track_2_indices], original_connex[track_2_indices]
+    )
+
+    # Test at time point 6 (Track 0 and 1 completed, Track 2 still active)
+    dims = Dims(
+        ndim=layer.ndim,
+        point=(6, 0, 0),
+        range=((0, 8, 1), (0, 50, 1), (0, 50, 1)),
+    )
+    layer._slice_dims(dims)
+    masked_connex_6 = layer.track_connex
+
+    # Track 0 and 1 should be masked
+    assert np.all(~masked_connex_6[track_0_indices])  # all False
+    assert np.all(~masked_connex_6[track_1_indices])  # all False
+
+    # Track 2 should still have original connections
+    np.testing.assert_array_equal(
+        masked_connex_6[track_2_indices], original_connex[track_2_indices]
+    )
+
+    # Test at time point 8 (all tracks completed)
+    dims = Dims(
+        ndim=layer.ndim,
+        point=(8, 0, 0),
+        range=((0, 10, 1), (0, 50, 1), (0, 50, 1)),
+    )
+    layer._slice_dims(dims)
+    all_masked_connex = layer.track_connex
+
+    # All tracks should be masked
+    assert np.all(~all_masked_connex)  # all False
+
+    # Test disabling hide_completed_tracks
+    layer.hide_completed_tracks = False
+    unmasked_connex = layer.track_connex
+
+    # Should return to original state
+    np.testing.assert_array_equal(unmasked_connex, original_connex)
 
 
 def test_docstring():

--- a/src/napari/layers/tracks/_track_utils.py
+++ b/src/napari/layers/tracks/_track_utils.py
@@ -44,7 +44,9 @@ class TrackManager:
         Vertices for N points in D dimensions. T,(Z),Y,X
     track_connex : array (N,)
         Connection array specifying consecutive vertices that are linked to
-        form the tracks. Boolean
+        form the tracks. When hide_completed_tracks is enabled, this
+        array is modified to hide tracks that have completed before the current
+        time point.
     track_times : array (N,)
         Timestamp for each vertex in track_vertices.
     graph_vertices : array (N, D)
@@ -56,6 +58,16 @@ class TrackManager:
         Timestamp for each vertex in graph_vertices.
     track_ids : array (N,)
         Track ID for each vertex in track_vertices.
+    hide_completed_tracks : bool
+        Whether to hide track segments that have completed before the current
+        time point, regardless of tail_length value.
+    current_time : int, optional
+        Current time point for determining which tracks have completed. Required
+        when hide_completed_tracks is enabled.
+    track_end_times : array (M,)
+        Cached array of end times for each unique track ID, where M is the
+        number of unique tracks. Computed lazily and invalidated when track
+        data changes.
     """
 
     def __init__(self, data: np.ndarray) -> None:
@@ -77,6 +89,13 @@ class TrackManager:
         self._graph: dict[int, list[int]] | None = None
         self._graph_vertices = None
         self._graph_connex: npt.NDArray | None = None
+
+        # Parameters for hide_completed_tracks functionality
+        self._hide_completed_tracks: bool = False
+        self._current_time: int | None = None
+        self._track_end_times: np.ndarray | None = (
+            None  # Cache for track end times (1D array ordered by unique_track_ids)
+        )
 
     @staticmethod
     def _fast_points_lookup(sorted_time: np.ndarray) -> dict[int, slice]:
@@ -140,6 +159,9 @@ class TrackManager:
             )
         ).tocsr()
 
+        # Invalidate cached track end times when data changes
+        self._track_end_times = None
+
     @property
     def features(self) -> pd.DataFrame:
         """Dataframe-like features table.
@@ -187,6 +209,26 @@ class TrackManager:
     def graph(self, graph: dict[int, int | list[int]]) -> None:
         """set the track graph"""
         self._graph = self._normalize_track_graph(graph)
+
+    @property
+    def hide_completed_tracks(self) -> bool:
+        """Whether to hide track segments that have completed before current time"""
+        return self._hide_completed_tracks
+
+    @hide_completed_tracks.setter
+    def hide_completed_tracks(self, value: bool) -> None:
+        """Set whether to hide completed tracks"""
+        self._hide_completed_tracks = value
+
+    @property
+    def current_time(self) -> int | None:
+        """Current time point for determining completed tracks"""
+        return self._current_time
+
+    @current_time.setter
+    def current_time(self, value: int | None) -> None:
+        """Set current time point"""
+        self._current_time = value
 
     @property
     def track_ids(self) -> npt.NDArray[np.uint32]:
@@ -291,6 +333,9 @@ class TrackManager:
         self._track_vertices = track_vertices
         self._track_connex = track_connex
 
+        # Invalidate cached track end times when tracks are rebuilt
+        self._track_end_times = None
+
     def build_graph(self) -> None:
         """build the track graph"""
 
@@ -364,6 +409,43 @@ class TrackManager:
         return None
 
     @property
+    def track_end_times(self) -> np.ndarray:
+        """Get cached track end times as 1D array ordered by unique_track_ids"""
+        if self._track_end_times is None:
+            self._track_end_times = self._compute_track_end_times()
+        return self._track_end_times
+
+    def _compute_track_end_times(self) -> np.ndarray:
+        """Compute the last timestamp for each track as 1D array (private method)"""
+        unique_ids = self.unique_track_ids
+        track_end_times = np.zeros(len(unique_ids), dtype=float)
+
+        for i, track_id in enumerate(unique_ids):
+            indices = self._vertex_indices_from_id(track_id)
+            track_end_times[i] = np.max(
+                self.data[indices, 1]
+            )  # max time for this track
+
+        return track_end_times
+
+    def _get_completed_tracks_mask(self) -> np.ndarray:
+        """Get boolean mask for vertices belonging to completed tracks"""
+        if self._current_time is None:
+            return np.zeros(len(self.data), dtype=bool)
+
+        # Get track end times as array and unique track IDs
+        track_end_times = self.track_end_times
+        unique_ids = self.unique_track_ids
+
+        # Create boolean mask for completed tracks (tracks that ended before current time)
+        completed_tracks_mask = track_end_times < self._current_time
+
+        completed_track_ids = unique_ids[completed_tracks_mask]
+        vertices_mask = np.isin(self.data[:, 0], completed_track_ids)
+
+        return vertices_mask
+
+    @property
     def track_vertices(self) -> np.ndarray | None:
         """return the track vertices"""
         return self._track_vertices
@@ -371,7 +453,16 @@ class TrackManager:
     @property
     def track_connex(self) -> np.ndarray | None:
         """vertex connections for drawing track lines"""
-        return self._track_connex
+        if self._track_connex is None:
+            return None
+
+        # If hide_completed_tracks is disabled or no current time set, return original connex
+        if not self._hide_completed_tracks or self._current_time is None:
+            return self._track_connex
+
+        # Get mask for completed tracks and return logical AND with original connex
+        completed_mask = self._get_completed_tracks_mask()
+        return np.logical_and(self._track_connex, ~completed_mask)
 
     @property
     def graph_vertices(self) -> np.ndarray | None:

--- a/src/napari/layers/tracks/tracks.py
+++ b/src/napari/layers/tracks/tracks.py
@@ -66,6 +66,9 @@ class Tracks(Layer):
         See examples/tracks_3d_with_graph.py
     head_length : float
         Length of the positive (forward in time) tails in units of time.
+    hide_completed_tracks : bool
+        If True, tracks that have completed before the current time point are not
+        displayed, regardless of the value of `tail_length`.
     metadata : dict
         Layer metadata.
     name : str
@@ -121,6 +124,7 @@ class Tracks(Layer):
         features=None,
         graph=None,
         head_length: int = 0,
+        hide_completed_tracks: bool = False,
         metadata=None,
         name=None,
         opacity=1.0,
@@ -174,6 +178,7 @@ class Tracks(Layer):
             properties=Event,
             rebuild_tracks=Event,
             rebuild_graph=Event,
+            hide_completed_tracks=Event,
         )
 
         # track manager deals with data slicing, graph building and properties
@@ -195,6 +200,7 @@ class Tracks(Layer):
         self.tail_width = tail_width
         self.tail_length = tail_length
         self.head_length = head_length
+        self.hide_completed_tracks = hide_completed_tracks
         self.display_id = False
         self.display_tail = True
         self.display_graph = True
@@ -257,6 +263,7 @@ class Tracks(Layer):
                 'tail_length': self.tail_length,
                 'head_length': self.head_length,
                 'features': self.features,
+                'hide_completed_tracks': self.hide_completed_tracks,
             }
         )
         return state
@@ -479,6 +486,18 @@ class Tracks(Layer):
         self.events.tail_width()
 
     @property
+    def hide_completed_tracks(self) -> bool:
+        """bool: If True, tracks that have completed before the current time
+        point are not displayed, regardless of the value of `tail_length`.
+        """
+        return self._hide_completed_tracks
+
+    @hide_completed_tracks.setter
+    def hide_completed_tracks(self, hide_completed_tracks: bool) -> None:
+        self._hide_completed_tracks: bool = hide_completed_tracks
+        self.events.hide_completed_tracks()
+
+    @property
     def tail_length(self) -> int:
         """float: Width for all vectors in pixels."""
         return self._tail_length
@@ -610,6 +629,9 @@ class Tracks(Layer):
     @property
     def track_connex(self) -> np.ndarray | None:
         """vertex connections for drawing track lines"""
+        # Update manager state before getting track_connex
+        self._manager.hide_completed_tracks = self._hide_completed_tracks
+        self._manager.current_time = self.current_time
         return self._manager.track_connex
 
     @property

--- a/tools/string_list.json
+++ b/tools/string_list.json
@@ -1993,6 +1993,7 @@
       "properties",
       "tail_length",
       "tail_width",
+      "hide_completed_tracks",
       "track_id",
       "turbo",
       "head_length",


### PR DESCRIPTION
Recreated from original PR: https://github.com/napari/napari/pull/8253

# References and relevant issues
Closes #7819.

# Description
This PR implements a new feature for the Tracks layer that allows users to hide tracks that have completely finished before the current time point, regardless of the `tail_length` setting. In other words, if the track is present at time `t` but not present at time `t+1`, then when you move the napari slider to time `t+1`, the track (i.e the full tail) disappear completely.

The concrete changes are as followed:
- New checkbox i...